### PR TITLE
Clarification for $.datahook('name') usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It extends jQuery adding the `$.datahook()` method.
 
 * **$.datahook()**: Selects all the hook elements.
 * **$.datahook('*')**: Same as `$.datahook()`.
-* **$.datahook('name')**: Selects any element with `data-hook="name"`.
+* **$.datahook('name')**: Selects elements with a `data-hook` attribute containing `name` (a `data-hook` attribute can be a single name or a space-separated list of names).
 
 Alternatively, it is possible to use the `$.hook()` alias.
 


### PR DESCRIPTION
For your consideration. Added explanation that an element can have multiple data-hook names as a space-separated list, and $.datahook('name') will match any within. Thanks!
